### PR TITLE
Better validation for attribute names

### DIFF
--- a/runtime/page/document.mjs
+++ b/runtime/page/document.mjs
@@ -305,11 +305,10 @@ export class ServerDocument
 function requireValidAttributeName(attributeName)
 {
     /*
-     * The HTML5 spec is much more permissive but lets
-     * just support the basics.
+     * Basic validation for valid attribute names, not comprehensive
+     * See https://stackoverflow.com/a/926136
      */
-
-    if (/[^a-zA-Z0-9-]/.test(attributeName))
+    if (/[\t\n\f \/>"'=]/.test(attributeName))
         throw Error("Invalid attribute name: " + attributeName);
 }
 


### PR DESCRIPTION
Simple adaptation from this StackOverflow answer https://stackoverflow.com/a/926136 for better HTML attribute name validation. Current validation became a roadblock for me to use `svg` element standard attribute `xmlns:svg`.