### PR TITLE
Fix unwanted white-space surrounding inline elements

### DIFF
--- a/build-system/nakedjsx.mjs
+++ b/build-system/nakedjsx.mjs
@@ -2344,7 +2344,7 @@ export default (await fsp.readFile(${JSON.stringify(asset.file)})).toString();`;
                             semi:                       false,
                             arrowParens:                'avoid',
                             quoteProps:                 'preserve',
-                            htmlWhitespaceSensitivity:  'ignore'
+                            htmlWhitespaceSensitivity:  'strict'
                         });
             
             writePromises.push(fsp.writeFile(fullPath, htmlContent));


### PR DESCRIPTION
This only happens with the `pretty` option.

Before this:

    <p>
      JSX (
      <strong>JavaScript Syntax Extension</strong>
      )
    </p>

After this:

    <p
        >JSX (<strong>JavaScript Syntax Extension</strong>)
    </p
        >

Prettier docs: https://prettier.io/docs/en/options.html#html-whitespace-sensitivity